### PR TITLE
fix: Removed newline character from Sprintf

### DIFF
--- a/db/sessions.go
+++ b/db/sessions.go
@@ -1,7 +1,6 @@
 package db
 
 import (
-	"fmt"
 	"time"
 
 	"github.com/CTS/AuthService/internal"
@@ -17,8 +16,7 @@ type Session struct {
 
 func createSessionID(email string) string {
 	// Create a unique session ID based on the email and current time
-	sessionID := internal.EncodeSHA256([]byte(email + time.Now().String()))
-	return fmt.Sprintf("%x", sessionID)
+	return internal.EncodeSHA256([]byte(email + time.Now().String()))
 }
 
 func SessionCreate(user *User, expiresAt time.Duration) (string, error) {

--- a/internal/hashing.go
+++ b/internal/hashing.go
@@ -23,5 +23,5 @@ func EncodeSHA256(data []byte) string {
 	// Compute the SHA256 hash
 	hash := sha256.Sum256(data)
 	// the hash in hexadecimal format
-	return fmt.Sprintf("%x\n", hash)
+	return fmt.Sprintf("%x", hash)
 }


### PR DESCRIPTION
Removed newline from Sprintf, which initially caused issues with DB lookups